### PR TITLE
Fix "asNavFor" bug

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -369,7 +369,8 @@
         if ( asNavFor !== null && typeof asNavFor === 'object' ) {
             asNavFor.each(function() {
                 var target = $(this).slick('getSlick');
-                if(!target.unslicked) {
+                var should_slide = !target.unslicked && target.slideCount > target.options.slidesToShow;
+                if(should_slide) {
                     target.slideHandler(index, true);
                 }
             });


### PR DESCRIPTION
When a slider is used as navigation, if the slides count is not greater than the slides to show option, will be still slided showing only all the slides from the current one on